### PR TITLE
Added bounce={false} on WebView props

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,6 +98,7 @@ const SignatureView = forwardRef(({
   return (
     <View style={styles.webBg}>
       <WebView
+        bounces={false}
         androidHardwareAccelerationDisabled={androidHardwareAccelerationDisabled}
         ref={webViewRef}
         useWebKit={true}


### PR DESCRIPTION
When dragging the footer up on ios simulator, it bounces and it may be annoying for the end-user. This PR might also save other dev's time because it took me some time to realize that it's on webview's props. I thought it's on the style or HTML.

![ezgif-1-56372db0a867](https://user-images.githubusercontent.com/39583750/99233809-b37f4080-282e-11eb-88ed-af5ecd49bef1.gif)



**Useful for this kind of UI.**

![anotha one](https://user-images.githubusercontent.com/39583750/99234764-e970f480-282f-11eb-92af-08cf0c6ae56e.gif)
