### PR TITLE
fix JSON syntax error in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npm publish",
-    "genlog": "conventional-changelog -p angular -i CHANGELOG.md -s",
+    "genlog": "conventional-changelog -p angular -i CHANGELOG.md -s"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi @YanYuanFE,

it looks like your yesterday change have introduced the syntax error in JSON file (https://github.com/YanYuanFE/react-native-signature-canvas/commit/e60a7a9e5b23d5bcddbf5101b292b1ad9526a70d):
* ```react-native-signature-canvas SyntaxError: Unexpected token } in JSON at position 297```

This small PR fixes the issues.