### PR TITLE
Fixed erasing and undoing, added a redo feature, implemented a background image and an overlay image

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![](https://img.shields.io/npm/v/react-native-signature-canvas)](https://www.npmjs.com/package/react-native-signature-canvas)
 ![npm](https://img.shields.io/npm/dt/react-native-signature-canvas)
 ![GitHub last commit](https://img.shields.io/github/last-commit/yanyuanfe/react-native-signature-canvas)
-
+[![runs with expo](https://img.shields.io/badge/Runs%20with%20Expo-4630EB.svg?style=flat&logo=EXPO&labelColor=f3f3f3&logoColor=000)](https://github.com/expo/expo)
 
 React Native Signature Component based Canvas for Android &amp;&amp; IOS &amp;&amp; expo
 
@@ -14,9 +14,15 @@ React Native Signature Component based Canvas for Android &amp;&amp; IOS &amp;&a
 - Core use [signature_pad.js](https://github.com/szimek/signature_pad)
 - Only depend on react and react native
 - Generates a base64 encoded png image of the signature
-Note: Expo support for React Native Signature Canvas v1.5.0 started with Expo SDK v33.0.0.
+  Note: Expo support for React Native Signature Canvas v1.5.0 started with Expo SDK v33.0.0.
 
 ## Installation(for React Native V0.60.0 or Expo SDK v35.0.0)
+
+```bash
+yarn add react-native-signature-canvas
+```
+
+or
 
 ```bash
 npm install --save react-native-signature-canvas
@@ -29,112 +35,182 @@ npm install --save react-native-signature-canvas@1.4.2
 ```
 
 ## Usage
-
-``` js
-import Signature from 'react-native-signature-canvas';
+Basic
+```js
+import Signature from "react-native-signature-canvas";
+```
+Custom
+```js
+import SignatureScreen from 'react-native-signature-canvas';
 ```
 
 ## Properties
--------------
-| Prop  | Type | Description |
-| :------------ |:---------------:| :---------------|
-| descriptionText | `string` | description text for signature |
-| clearText | `string` | clear button text |
-| confirmText | `string` | save button text |
-| webStyle | `string` | webview style for overwrite default style, all style: https://github.com/YanYuanFE/react-native-signature-canvas/blob/master/h5/css/signature-pad.css |
-| onOK | `function` | handle function when you click save button |
-| onEmpty | `function` | handle function of empty signature when you click save button |
-| onClear | `function` | handle function when you click clear button
-| onBegin | `function` | handle function when a new stroke is started
-| onEnd | `function` | handle function when the stroke has ended
-| customHtml | `function` | html string that lets you modify things like the layout or elements.
-| autoClear | `boolean` | is auto clear the signature after click confirm button
-| trimWhitespace | `boolean` | trim image whitespace
-| rotated | `boolean` | rotate signature pad 90 degrees
-| imageType | `string` | default is "", "image/jpeg"、"image/svg+xml", imageType of export signature
-| dataURL | `string` | default is "", Base64 string, Draws signature image from data URL.
-| penColor | `string` | default is "black", color of pen
-| backgroundColor | `string` | default is "rgba(255,255,255,1)", backgroundColor of canvas
-| dotSize | `number` | radius of a single dot
-| minWidth | `number` | minimum width of a line. Defaults to 0.5
-| androidHardwareAccelerationDisabled | `boolean` |androidHardwareAccelerationDisabled for react-native-webview. Default is false
-| style | `object` | style of wrapper view
+
+---
+
+| Prop                                |    Type    | Description                                                                                                                                           |
+| :---------------------------------- | :--------: | :---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| androidHardwareAccelerationDisabled | `boolean`  | androidHardwareAccelerationDisabled for react-native-webview. Default is false                                                                        |
+| autoClear                           | `boolean`  | should auto clear the signature after clicking the Confirm button                                                                                     |
+| backgroundColor                     |  `string`  | default is "rgba(255,255,255,0)" (_transparent_), background color of the canvas                                                                                           |
+| bgHeight                            |  `number`  | height of the background image                                                                                                                        |
+| bgWidth                             |  `number`  | width of the background image                                                                                                                         |
+| bgSrc                               |  `string`  | background image source uri (_html_)                                                                                                                  |
+| clearText                           |  `string`  | clear button text                                                                                                                                     |
+| confirmText                         |  `string`  | save button text                                                                                                                                      |
+| customHtml                          | `function` | html string that lets you modify things like the layout or elements                                                                                   |
+| dataURL                             |  `string`  | default is "", Base64 string, draws saved signature from dataURL.                                                                                     |
+| descriptionText                     |  `string`  | description text for signature                                                                                                                        |
+| dotSize                             |  `number`  | radius of a single dot _(not stroke width)_                                                                                                           |
+| imageType                           |  `string`  | "image/png" (_default_), "image/jpeg"、"image/svg+xml", imageType of exported signature                                                               |
+| minWidth                            |  `number`  | minimum width of a line. Defaults to 0.5                                                                                                              |
+| maxWidth                            |  `number`  | maximum width of a line. Defaults to 2.5                                                                                                              |
+| onOK                                | `function` | callback function after saving non-empty signature                                                                                                    |
+| onEmpty                             | `function` | callback function after trying to save an empty signature                                                                                             |
+| onClear                             | `function` | callback function after clearing the signature                                                                                                        |
+| onBegin                             | `function` | callback function when a new stroke is started                                                                                                        |
+| onEnd                               | `function` | callback function when the stroke has ended                                                                                                           |
+| onUndo                              | `function` | callback function when undo() is called                                                                                                               |
+| onDraw                              | `function` | callback function when drawing is enabled                                                                                                             |
+| onErase                             | `function` | callback function when erasing is enabled                                                                                                             |
+| onChangePenColor                    | `function` | callback function after changing the pen color |
+|overlayHeight|`number`|height of the overlay image|
+|overlayWidth|`number`|width of the overlay image|
+|overlaySrc|`string`|overlay image source uri (html) _must be .png with a transparent background_
+| penColor                            |  `string`  | default is "black", color of pen                                                                                                                      |
+| rotated                             | `boolean`  | rotate signature pad 90 degrees                                                                                                                       |
+| style                               |  `object`  | style of wrapper view                                                                                                                                 |
+| trimWhitespace                      | `boolean`  | trim image whitespace                                                                                                                                 |
+| webStyle                            |  `string`  | webview style for overwrite default style, all style: https://github.com/YanYuanFE/react-native-signature-canvas/blob/master/h5/css/signature-pad.css |
 
 ## Methods
--------------
-| Function  | Description |
-| :------------ |:---------------|
-| readSignature() | Reads the current signature on the canvas and triggers either the onOK or onEmpty callbacks |
-| clearSignature() | Clears the current signature |
-| undo() | undo signature |
-| erase() | erase signature |
-| draw() | draw signature |
-| changePenColor(color) | change pen color |
 
-You need to use ref like:
-``` js
-import SignatureScreen from 'react-native-signature-canvas';
+---
 
-const Sign = ({text, onOK}) => {
+| Function              | Description                                                                                 |
+| :-------------------- | :------------------------------------------------------------------------------------------ |
+| clearSignature()      | Clear the current signature                                                                 |
+| changePenColor(color) | Change pen color                                                                            |
+| draw()                | Enable drawing signature                                                                    |
+| erase()               | Enable erasing signature                                                                    |
+| readSignature()       | Reads the current signature on the canvas and triggers either the onOK or onEmpty callbacks |
+| undo()                | Undo last stroke                                                                            |
+
+To call the methods use the `useRef` hook:
+
+```js
+import SignatureScreen from "react-native-signature-canvas";
+
+const Sign = ({ text, onOK }) => {
   const ref = useRef();
 
-  const handleSignature = signature => {
+  // Called after ref.current.readSignature() reads a non-empty base64 string
+  const handleOK = (signature) => {
     console.log(signature);
-    onOK(signature);
+    onOK(signature); // Callback from Component props
   };
 
+  // Called after ref.current.readSignature() reads an empty string
   const handleEmpty = () => {
-    console.log('Empty');
-  }
+    console.log("Empty");
+  };
 
+  // Called after ref.current.clearSignature()
   const handleClear = () => {
-    console.log('clear success!');
-  }
+    console.log("clear success!");
+  };
 
+  // Called after end of stroke
   const handleEnd = () => {
-      ref.current.readSignature();
-  }
+    ref.current.readSignature();
+  };
 
   return (
     <SignatureScreen
-        ref={ref}
-        onEnd={handleEnd}
-        onOK={handleSignature}
-        onEmpty={handleEmpty}
-        onClear={handleClear}
-        autoClear={true}
-        descriptionText={text}
+      ref={ref}
+      onEnd={handleEnd}
+      onOK={handleOK}
+      onEmpty={handleEmpty}
+      onClear={handleClear}
+      autoClear={true}
+      descriptionText={text}
     />
   );
-}
+};
 
 export default Sign;
 ```
+## Using a background image
+You can use a non-erasable background image to draw your signature on using the `bgSrc` prop. Make sure to provide the width and height of the image.
 
-##  Save Base64 Image as File
+```js
+const imgWidth = 300;
+const imgHeight = 200;
+const style = `.m-signature-pad {box-shadow: none; border: none; } 
+              .m-signature-pad--body {border: none;}
+              .m-signature-pad--footer {display: none; margin: 0px;}
+              body,html {
+              width: ${imgWidth}px; height: ${imgHeight}px;}`;
+...
+<View style={{ width: imgWidth, height: imgHeight }}>
+  <SignatureScreen
+    ref={ref}
+    bgSrc="https://via.placeholder.com/300x200/ff726b"
+    bgWidth={imgWidth}
+    bgHeight={imgHeight}
+    webStyle={style}
+    onOK={handleOK}
+  />
+</View>
+```
 
-If you use expo, you can use **expo-file-system** for save base64 image as local file, if you use react-native-cli, use **react-native-fs**.
+## Using an overlay image
+An overlay is a non-erasable image that can be used to "guide" the drawing, similar to lines in a colouring book. Make sure the image format is .png and that it has a transparent background. Also, don't forget to provide the width and height of the image.
 
-``` js
-import * as FileSystem from 'expo-file-system';
+```js
+const imgWidth = 256;
+const imgHeight = 256;
+const style = `.m-signature-pad {box-shadow: none; border: none; } 
+              .m-signature-pad--body {border: none;}
+              .m-signature-pad--footer {display: none; margin: 0px;}
+              body,html {
+              width: ${imgWidth}px; height: ${imgHeight}px;}`;
+...
+<View style={{ width: imgWidth, height: imgHeight }}>
+  <SignatureScreen
+    ref={ref}
+    overlaySrc="http://pngimg.com/uploads/circle/circle_PNG63.png"
+    overlayWidth={imgWidth}
+    overlayHeight={imgHeight}
+    webStyle={style}
+    onOK={handleOK}
+  />
+</View>
+```
 
-const handleSignature = signature => {
-    const path = FileSystem.cacheDirectory + 'sign.png';
-    FileSystem.writeAsStringAsync(path, signature.replace('data:image/png;base64,', ''), {encoding: FileSystem.EncodingType.Base64}).then(res => {
-      console.log(res);
-      FileSystem.getInfoAsync(path, {size: true, md5: true}).then(file => {
-        console.log(file);
-      })
-    }).catch(err => {
-      console.log("err", err);
-    })
+## Save Base64 Image as File
+
+If you use expo, you can use **expo-file-system** to save the base64 image as a local file; if you're working with react-native-cli, use **react-native-fs**.
+
+```js
+import * as FileSystem from "expo-file-system";
+
+const handleOK = (signature) => {
+  const path = FileSystem.cacheDirectory + "sign.png";
+  FileSystem.writeAsStringAsync(
+    path,
+    signature.replace("data:image/png;base64,", ""),
+    { encoding: FileSystem.EncodingType.Base64 }
+  )
+    .then(() => FileSystem.getInfoAsync(path))
+    .then(console.log)
+    .catch(console.error);
 };
-
 ```
 
 ## Basic parameters
 
-``` js
+```js
 <Signature
   // handle when you click save button
   onOK={(img) => console.log(img)}
@@ -150,16 +226,15 @@ const handleSignature = signature => {
     .button {
       background-color: red;
       color: #FFF;
-    }`
-  }
+    }`}
   autoClear={true}
   imageType={"image/svg+xml"}
 />
-
 ```
+
 If you create your own triggers for the readSignature and/or clearSignature you can hide the built in Clear and Save buttons with css styles passed into the **webStyle** property.
 
-``` js
+```js
 const webStyle = `.m-signature-pad--footer
     .save {
         display: none;
@@ -180,98 +255,85 @@ const webStyle = `.m-signature-pad--footer
 
 ## Custom Button for Confirm and Clear
 
-``` js
-import React, {useRef} from 'react';
-import { StyleSheet, View, Button } from 'react-native';
-import SignatureScreen from 'react-native-signature-canvas';
+```js
+import React, { useRef } from "react";
+import { StyleSheet, View, Button } from "react-native";
+import SignatureScreen from "react-native-signature-canvas";
 
-const Sign = ({onOK}) => {
+const Sign = ({ onOK }) => {
   const ref = useRef();
 
-  const handleSignature = signature => {
+  const handleOK = (signature) => {
     console.log(signature);
     onOK(signature);
   };
 
   const handleClear = () => {
     ref.current.clearSignature();
-  }
+  };
 
   const handleConfirm = () => {
     console.log("end");
     ref.current.readSignature();
-  }
+  };
 
   const style = `.m-signature-pad--footer {display: none; margin: 0px;}`;
 
   return (
     <View style={styles.container}>
-      <SignatureScreen
-          ref={ref}
-          onOK={handleSignature} 
-          webStyle={style}
-      />
+      <SignatureScreen ref={ref} onOK={handleOK} webStyle={style} />
       <View style={styles.row}>
-        <Button
-            title="Clear"
-            onPress={handleClear}
-        />
-        <Button
-          title="Confirm"
-          onPress={handleConfirm}
-        />
+        <Button title="Clear" onPress={handleClear} />
+        <Button title="Confirm" onPress={handleConfirm} />
       </View>
     </View>
   );
-}
+};
 
 export default Sign;
 
 const styles = StyleSheet.create({
   container: {
     flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
+    alignItems: "center",
+    justifyContent: "center",
     height: 250,
     padding: 10,
   },
   row: {
     display: "flex",
     flexDirection: "row",
-    justifyContent: 'space-between',
-    width: '100%',
-    alignItems: 'center',
-  }
+    justifyContent: "space-between",
+    width: "100%",
+    alignItems: "center",
+  },
 });
-
 ```
-
 
 ## Example
 
-* Android <br/>
-<img src="http://img.yanyuanfe.cn/signature-android.png" width="400" />
+- Android <br/>
+  <img src="http://img.yanyuanfe.cn/signature-android.png" width="400" />
 
-*  iOS <br/>
-<img src="http://img.yanyuanfe.cn/signature-ios.png" width="400" />
-
+- iOS <br/>
+  <img src="http://img.yanyuanfe.cn/signature-ios.png" width="400" />
 
 ```js
-import React, { useState } from 'react';
-import { StyleSheet, Text, View, Image } from 'react-native';
-import Signature from 'react-native-signature-canvas';
+import React, { useState } from "react";
+import { StyleSheet, Text, View, Image } from "react-native";
+import Signature from "react-native-signature-canvas";
 
 export const SignatureScreen = () => {
   const [signature, setSign] = useState(null);
 
-  const handleSignature = signature => {
+  const handleOK = (signature) => {
     console.log(signature);
     setSign(signature);
   };
 
   const handleEmpty = () => {
-    console.log('Empty');
-  }
+    console.log("Empty");
+  };
 
   const style = `.m-signature-pad--footer
     .button {
@@ -290,7 +352,7 @@ export const SignatureScreen = () => {
         ) : null}
       </View>
       <Signature
-        onOK={handleSignature}
+        onOK={handleOK}
         onEmpty={handleEmpty}
         descriptionText="Sign"
         clearText="Clear"
@@ -299,7 +361,7 @@ export const SignatureScreen = () => {
       />
     </View>
   );
-}
+};
 
 const styles = StyleSheet.create({
   preview: {
@@ -308,7 +370,7 @@ const styles = StyleSheet.create({
     backgroundColor: "#F8F8F8",
     justifyContent: "center",
     alignItems: "center",
-    marginTop: 15
+    marginTop: 15,
   },
   previewText: {
     color: "#FFF",
@@ -320,8 +382,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#69B2FF",
     width: 120,
     textAlign: "center",
-    marginTop: 10
-  }
+    marginTop: 10,
+  },
 });
 ```
 
@@ -330,49 +392,50 @@ const styles = StyleSheet.create({
 To use Typescript just import `SignatureViewRef` and in [useRef hook](https://reactjs.org/docs/hooks-reference.html#useref) inform that the reference is of the `SignatureViewRef` type, with that the `readSignature` and `clearSignature` methods will be available.
 
 ```ts
-import React, { useRef } from 'react';
-import SignatureScreen, { SignatureViewRef } from 'react-native-signature-canvas';
+import React, { useRef } from "react";
+import SignatureScreen, {
+  SignatureViewRef,
+} from "react-native-signature-canvas";
 
 interface Props {
   text: string;
   onOK: (signature) => void;
 }
 
-const Sign: React.FC<Props> = ({text, onOK}) => {
+const Sign: React.FC<Props> = ({ text, onOK }) => {
   const ref = useRef<SignatureViewRef>(null);
 
-  const handleSignature = signature => {
+  const handleSignature = (signature) => {
     console.log(signature);
     onOK(signature);
   };
 
   const handleEmpty = () => {
-    console.log('Empty');
-  }
+    console.log("Empty");
+  };
 
   const handleClear = () => {
-    console.log('clear success!');
-  }
+    console.log("clear success!");
+  };
 
   const handleEnd = () => {
-      ref.current?.readSignature();
-  }
+    ref.current?.readSignature();
+  };
 
   return (
     <SignatureScreen
-        ref={ref}
-        onEnd={handleEnd}
-        onOK={handleSignature}
-        onEmpty={handleEmpty}
-        onClear={handleClear}
-        autoClear={true}
-        descriptionText={text}
+      ref={ref}
+      onEnd={handleEnd}
+      onOK={handleSignature}
+      onEmpty={handleEmpty}
+      onClear={handleClear}
+      autoClear={true}
+      descriptionText={text}
     />
   );
-}
+};
 
 export default Sign;
-
 ```
 
 ## Example inside ScrollView

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ const style = `.m-signature-pad {box-shadow: none; border: none; }
 
 ## Using an overlay image
 An overlay is a non-erasable image that can be used to "guide" the drawing, similar to lines in a colouring book. Make sure the image format is .png and that it has a transparent background. Also, don't forget to provide the width and height of the image.
+Use the `overlaySrc` prop to provide the link.
 
 ```js
 const imgWidth = 256;
@@ -389,7 +390,7 @@ const styles = StyleSheet.create({
 
 ## Using Typescript
 
-To use Typescript just import `SignatureViewRef` and in [useRef hook](https://reactjs.org/docs/hooks-reference.html#useref) inform that the reference is of the `SignatureViewRef` type, with that the `readSignature` and `clearSignature` methods will be available.
+To use Typescript just import `SignatureViewRef` and in [useRef hook](https://reactjs.org/docs/hooks-reference.html#useref) inform that the reference is of the `SignatureViewRef` type, with that the regular `ref` methods will be available.
 
 ```ts
 import React, { useRef } from "react";

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ import SignatureScreen from 'react-native-signature-canvas';
 | onClear                             | `function` | callback function after clearing the signature                                                                                                        |
 | onBegin                             | `function` | callback function when a new stroke is started                                                                                                        |
 | onEnd                               | `function` | callback function when the stroke has ended                                                                                                           |
-| onUndo                              | `function` | callback function when undo() is called                                                                                                               |
+| onUndo                              | `function` | callback function when undo() is called |
+| onRedo                              | `function` | callback function when redo() is called |
 | onDraw                              | `function` | callback function when drawing is enabled                                                                                                             |
 | onErase                             | `function` | callback function when erasing is enabled                                                                                                             |
 | onChangePenColor                    | `function` | callback function after changing the pen color |
@@ -95,6 +96,7 @@ import SignatureScreen from 'react-native-signature-canvas';
 | erase()               | Enable erasing signature                                                                    |
 | readSignature()       | Reads the current signature on the canvas and triggers either the onOK or onEmpty callbacks |
 | undo()                | Undo last stroke                                                                            |
+| redo()                | Redo last stroke                                                                            |
 
 To call the methods use the `useRef` hook:
 

--- a/h5/html.js
+++ b/h5/html.js
@@ -1,5 +1,5 @@
-const content = script =>
-    `<!doctype html>
+export default (script) =>
+  `<!doctype html>
 <html lang="en">
 <head>
   <meta charset="utf-8">
@@ -152,10 +152,12 @@ const content = script =>
     </style>
 </head>
 <body onselectstart="return false">
-<div class="rotated-<%orientation%>">
+  <div class="rotated-<%orientation%>">
     <div id="signature-pad" class="m-signature-pad">
       <div class="m-signature-pad--body">
+        <img style="position: absolute; top: 0; left: 0; pointer-events: none;" src=<%bgSrc%> width=<%bgWidth%> height=<%bgHeight%> />
         <canvas></canvas>
+        <img style="position: absolute; top: 0; left: 0; pointer-events: none;" src=<%overlaySrc%> width=<%overlayWidth%> height=<%overlayHeight%> />
       </div>
       <div class="m-signature-pad--footer">
         <button type="button" class="button clear" data-action="clear"><%clear%></button>
@@ -170,5 +172,3 @@ const content = script =>
   </script>
 </body>
 </html>`;
-
-export default content;

--- a/h5/js/app.js
+++ b/h5/js/app.js
@@ -45,6 +45,11 @@ export default `
         window.ReactNativeWebView.postMessage("UNDO");
     }
     
+    function redo() {
+        signaturePad.redo();
+        window.ReactNativeWebView.postMessage("REDO");
+      }
+
     function changePenColor(color){
         signaturePad.penColor = color;
         window.ReactNativeWebView.postMessage("CHANGE_PEN");

--- a/h5/js/app.js
+++ b/h5/js/app.js
@@ -1,4 +1,4 @@
-const content = `
+export default `
     var wrapper = document.getElementById("signature-pad"),
         clearButton = wrapper.querySelector("[data-action=clear]"),
         saveButton = wrapper.querySelector("[data-action=save]"),
@@ -32,65 +32,44 @@ const content = `
         backgroundColor: '<%backgroundColor%>',
         dotSize: <%dotSize%>,
         minWidth: <%minWidth%>,
+        maxWidth: <%maxWidth%>,
     });
 
-    function clearSignature (event) {
+    function clearSignature () {
         signaturePad.clear();
         window.ReactNativeWebView.postMessage("CLEAR");
     }
     
-    function undo(event){
-        var data = signaturePad.toData();
-        if (data) {
-        data.pop(); // remove the last dot or line
-        signaturePad.fromData(data);
-        }
+    function undo() {
+        signaturePad.undo();
         window.ReactNativeWebView.postMessage("UNDO");
     }
     
     function changePenColor(color){
-        signaturePad.penColor=color;
+        signaturePad.penColor = color;
         window.ReactNativeWebView.postMessage("CHANGE_PEN");
     }
     
-    function getData (event) {
+    function getData () {
         var data = signaturePad.toData();
         window.ReactNativeWebView.postMessage(JSON.stringify(data));
     }
 
-
-    function draw(event){
-        //signaturePad.minWidth= 0.5;
-        //signaturePad.maxWidth= 2.5;
-        var ctx = canvas.getContext('2d');
-        console.log(ctx.globalCompositeOperation);
-        ctx.globalCompositeOperation = 'source-over';
-        window.ReactNativeWebView.postMessage("DRAW");
+    function draw() {
+      //signaturePad.minWidth= 0.5;
+      //signaturePad.maxWidth= 2.5;
+      signaturePad.draw();
+      window.ReactNativeWebView.postMessage("DRAW");
     }
 
-    function erase(event){
-        //signaturePad.minWidth= 5;
-        //signaturePad.maxWidth= 10;
-        var ctx = canvas.getContext('2d');
-        ctx.globalCompositeOperation = 'destination-out';
-        window.ReactNativeWebView.postMessage("ERASE");
-    }
-
-
-    clearButton.addEventListener("click", clearSignature );
-
-    var autoClear = <%autoClear%>;
-    
-    var trimWhitespace = <%trimWhitespace%>;
-
-    var dataURL = '<%dataURL%>';
-
-    if (dataURL) {
-        signaturePad.fromDataURL(dataURL);
+    function erase() {
+      //signaturePad.minWidth= 5;
+      //signaturePad.maxWidth= 10;
+      signaturePad.erase();
+      window.ReactNativeWebView.postMessage("ERASE");
     }
 
     function cropWhitespace(url) {
-
         var myImage = new Image();
         myImage.crossOrigin = "Anonymous";
         myImage.onload = function(){
@@ -188,16 +167,22 @@ const content = `
         } else {
             var url = signaturePad.toDataURL('<%imageType%>');
             trimWhitespace? cropWhitespace(url): window.ReactNativeWebView.postMessage(url);
-            if (autoClear) {
-                signaturePad.clear();
-            }
+            if (autoClear) signaturePad.clear();
         }
     }
 
-     saveButton.addEventListener("click", () => {    
-        readSignature();
-        getData();    
-   });
-`;
+    var autoClear = <%autoClear%>;
+    
+    var trimWhitespace = <%trimWhitespace%>;
 
-export default content;
+    var dataURL = '<%dataURL%>';
+
+    if (dataURL) signaturePad.fromDataURL(dataURL);
+
+    clearButton.addEventListener("click", clearSignature );
+
+    saveButton.addEventListener("click", () => {    
+      readSignature();
+      getData();    
+    });
+`;

--- a/h5/js/signature_pad.js
+++ b/h5/js/signature_pad.js
@@ -144,6 +144,7 @@ export default `
           this.options = options;
           this._startingSignature = null;
           this._isDrawing = true;
+          this._history = [];
           this._handleMouseDown = function (event) {
               if (event.which === 1) {
                   _this._mouseButtonDown = true;
@@ -214,10 +215,21 @@ export default `
       SignaturePad.prototype.undo = function () {
         const data = this.toData();
         if (data && data.length) {
-            data.pop(); // remove the last stroke
+            this._history.push(data.pop()); // remove the last stroke
         } else if (this._startingSignature) {
             return; // they performed undo of background sig
         }
+        this.clear();
+        if (this._startingSignature) {
+            this.fromDataURL(this._startingSignature, {}, () => this.fromData(data, true));
+        } else {
+            this.fromData(data, true);
+        }
+      };
+      SignaturePad.prototype.redo = function () {
+        if (!this._history.length) return;
+        const data = this.toData();
+        data.push(this._history.pop());
         this.clear();
         if (this._startingSignature) {
             this.fromDataURL(this._startingSignature, {}, () => this.fromData(data, true));
@@ -324,6 +336,7 @@ export default `
           this.onBegin(event);
         }
         this._data.push(newPointGroup);
+        this._history = [];
         this._reset();
         this._strokeUpdate(event);
       };

--- a/h5/js/signature_pad.js
+++ b/h5/js/signature_pad.js
@@ -1,4 +1,4 @@
-const content = `
+export default `
 /*!
  * Signature Pad v3.0.0-beta.3 | https://github.com/szimek/signature_pad
  * (c) 2018 Szymon Nowak | Released under the MIT license
@@ -138,10 +138,12 @@ const content = `
 
   var SignaturePad = (function () {
       function SignaturePad(canvas, options) {
-          if (options === void 0) { options = {}; }
+          if (options === void 0) options = {};
           var _this = this;
           this.canvas = canvas;
           this.options = options;
+          this._startingSignature = null;
+          this._isDrawing = true;
           this._handleMouseDown = function (event) {
               if (event.which === 1) {
                   _this._mouseButtonDown = true;
@@ -182,26 +184,20 @@ const content = `
           this.velocityFilterWeight = options.velocityFilterWeight || 0.7;
           this.minWidth = options.minWidth || 0.5;
           this.maxWidth = options.maxWidth || 2.5;
-          this.throttle = ('throttle' in options ? options.throttle : 16);
-          this.minDistance = ('minDistance' in options
-              ? options.minDistance
-              : 5);
-          if (this.throttle) {
-              this._strokeMoveUpdate = throttle(SignaturePad.prototype._strokeUpdate, this.throttle);
-          }
-          else {
-              this._strokeMoveUpdate = SignaturePad.prototype._strokeUpdate;
-          }
-          this.dotSize =
-              options.dotSize ||
-                  function dotSize() {
-                      return (this.minWidth + this.maxWidth) / 2;
-                  };
-          this.penColor = options.penColor || 'black';
-          this.backgroundColor = options.backgroundColor || 'rgba(255,255,255,1)';
+          this.throttle = "throttle" in options ? options.throttle : 16;
+          this.minDistance = "minDistance" in options ? options.minDistance : 5;
+          this._strokeMoveUpdate = this.throttle
+            ? (this._strokeMoveUpdate = throttle(
+                SignaturePad.prototype._strokeUpdate,
+                this.throttle
+              ))
+            : SignaturePad.prototype._strokeUpdate;
+          this.dotSize = options.dotSize || (this.minWidth + this.maxWidth) / 2;
+          this.penColor = options.penColor || "black";
+          this.backgroundColor = options.backgroundColor || "rgba(255,255,255,0)";
           this.onBegin = options.onBegin;
           this.onEnd = options.onEnd;
-          this._ctx = canvas.getContext('2d');
+          this._ctx = canvas.getContext("2d");
           this.clear();
           this.on();
       }
@@ -215,16 +211,41 @@ const content = `
           this._reset();
           this._isEmpty = true;
       };
+      SignaturePad.prototype.undo = function () {
+        const data = this.toData();
+        if (data && data.length) {
+            data.pop(); // remove the last stroke
+        } else if (this._startingSignature) {
+            return; // they performed undo of background sig
+        }
+        this.clear();
+        if (this._startingSignature) {
+            this.fromDataURL(this._startingSignature, {}, () => this.fromData(data, true));
+        } else {
+            this.fromData(data, true);
+        }
+      };
+      SignaturePad.prototype.draw = function () {
+        this._ctx.globalCompositeOperation = "source-over";
+        this._isDrawing = true;
+      };
+      SignaturePad.prototype.erase = function () {
+        this._ctx.globalCompositeOperation = "destination-out";
+        this._isDrawing = false;
+      };
       SignaturePad.prototype.fromDataURL = function (dataUrl, options, callback) {
           var _this = this;
-          if (options === void 0) { options = {}; }
+          if (options === void 0) options = {};
           var image = new Image();
           var ratio = options.ratio || window.devicePixelRatio || 1;
           var width = options.width || this.canvas.width / ratio;
           var height = options.height || this.canvas.height / ratio;
           this._reset();
+          image.src = dataUrl;
           image.onload = function () {
-              _this._ctx.drawImage(image, 0, 0, width, height);
+            _this._ctx.globalCompositeOperation = "source-over";
+            _this._ctx.drawImage(image, 0, 0, width, height);
+            _this._ctx.globalCompositeOperation = _this._isDrawing ? "source-over" : "destination-out";
               if (callback) {
                   callback();
               }
@@ -234,8 +255,8 @@ const content = `
                   callback(error);
               }
           };
-          image.src = dataUrl;
           this._isEmpty = false;
+          if (!this._startingSignature) this._startingSignature = dataUrl;
       };
       SignaturePad.prototype.toDataURL = function (type, encoderOptions) {
           if (type === void 0) { type = 'image/png'; }
@@ -275,32 +296,36 @@ const content = `
       SignaturePad.prototype.isEmpty = function () {
           return this._isEmpty;
       };
-      SignaturePad.prototype.fromData = function (pointGroups) {
-          var _this = this;
-          this.clear();
-          this._fromData(pointGroups, function (_a) {
-              var color = _a.color, curve = _a.curve;
-              return _this._drawCurve({ color: color, curve: curve });
-          }, function (_a) {
-              var color = _a.color, point = _a.point;
-              return _this._drawDot({ color: color, point: point });
-          });
+      SignaturePad.prototype.fromData = function (pointGroups, suppressClear = false) {
+        var _this = this;
+        if (!suppressClear) this.clear();
+        if (pointGroups && pointGroups.length > 0) {
+          this._fromData(
+            pointGroups,
+            ({ color, curve }) => _this._drawCurve({ color, curve }),
+            ({ color, point }) => _this._drawDot({ color, point })
+          );
           this._data = pointGroups;
+        }
       };
       SignaturePad.prototype.toData = function () {
           return this._data;
       };
       SignaturePad.prototype._strokeBegin = function (event) {
-          var newPointGroup = {
-              color: this.penColor,
-              points: []
-          };
-          if (typeof this.onBegin === 'function') {
-              this.onBegin(event);
-          }
-          this._data.push(newPointGroup);
-          this._reset();
-          this._strokeUpdate(event);
+        var newPointGroup = {
+          color: this.penColor,
+          dotSize: this.dotSize, // Enhance undo
+          minWidth: this.minWidth, // Enhance undo
+          maxWidth: this.maxWidth, // Enhance undo
+          compositeOperation: this._ctx.globalCompositeOperation, // Fix undo problem
+          points: [],
+        };
+        if (typeof this.onBegin === "function") {
+          this.onBegin(event);
+        }
+        this._data.push(newPointGroup);
+        this._reset();
+        this._strokeUpdate(event);
       };
       SignaturePad.prototype._strokeUpdate = function (event) {
           var x = event.clientX;
@@ -316,10 +341,10 @@ const content = `
           if (!lastPoint || !(lastPoint && isLastPointTooClose)) {
               var curve = this._addPoint(point);
               if (!lastPoint) {
-                  this._drawDot({ color: color, point: point });
+                  this._drawDot({ color, point });
               }
               else if (curve) {
-                  this._drawCurve({ color: color, curve: curve });
+                  this._drawCurve({ color, curve });
               }
               lastPoints.push({
                   time: point.time,
@@ -429,41 +454,48 @@ const content = `
           ctx.fill();
       };
       SignaturePad.prototype._drawDot = function (_a) {
-          var color = _a.color, point = _a.point;
-          var ctx = this._ctx;
-          var width = typeof this.dotSize === 'function' ? this.dotSize() : this.dotSize;
-          ctx.beginPath();
-          this._drawCurveSegment(point.x, point.y, width);
-          ctx.closePath();
-          ctx.fillStyle = color;
-          ctx.fill();
+        var color = _a.color,
+          point = _a.point;
+        var ctx = this._ctx;
+        //var width = typeof this.dotSize === "function" ? this.dotSize() : this.dotSize;
+        var width = typeof _a.dotSize
+          ? _a.dotSize
+          : typeof this.dotSize === "function"
+          ? this.dotSize()
+          : this.dotSize; // Enhance undo
+        ctx.beginPath();
+        this._drawCurveSegment(point.x, point.y, width);
+        ctx.closePath();
+        ctx.fillStyle = color;
+        ctx.fill();
       };
       SignaturePad.prototype._fromData = function (pointGroups, drawCurve, drawDot) {
-          for (var _i = 0, pointGroups_1 = pointGroups; _i < pointGroups_1.length; _i++) {
-              var group = pointGroups_1[_i];
-              var color = group.color, points = group.points;
-              if (points.length > 1) {
-                  for (var j = 0; j < points.length; j += 1) {
-                      var basicPoint = points[j];
-                      var point = new Point(basicPoint.x, basicPoint.y, basicPoint.time);
-                      this.penColor = color;
-                      if (j === 0) {
-                          this._reset();
-                      }
-                      var curve = this._addPoint(point);
-                      if (curve) {
-                          drawCurve({ color: color, curve: curve });
-                      }
-                  }
-              }
-              else {
-                  this._reset();
-                  drawDot({
-                      color: color,
-                      point: points[0]
-                  });
-              }
-          }
+        for (var i = 0; i < pointGroups.length; i++) {
+          var group = pointGroups[i];
+          var color = group.color,
+            points = group.points;
+          var minWidth = group.minWidth,
+            maxWidth = group.maxWidth; // Enhance undo
+          var compositeOperation = group.compositeOperation; // Fix undo problem
+          this._reset();
+          if (points.length > 1) {
+            for (var j = 0; j < points.length; j++) {
+              var basicPoint = points[j];
+              var point = new Point(
+                basicPoint.x,
+                basicPoint.y,
+                basicPoint.time
+              );
+              // this.penColor = color;
+              this.minWidth = minWidth; // Enhance undo
+              this.maxWidth = maxWidth; // Enhance undo
+              this._ctx.globalCompositeOperation = compositeOperation; // Fix undo problem
+              var curve = this._addPoint(point);
+              if (curve) drawCurve({ color, curve });
+            }
+          } else drawDot({ color, point: points[0] });
+        }
+        this._ctx.globalCompositeOperation = this._isDrawing ? "source-over" : "destination-out";
       };
       SignaturePad.prototype._toSVG = function () {
           var _this = this;
@@ -495,14 +527,20 @@ const content = `
                   svg.appendChild(path);
               }
           }, function (_a) {
-              var color = _a.color, point = _a.point;
-              var circle = document.createElement('circle');
-              var dotSize = typeof _this.dotSize === 'function' ? _this.dotSize() : _this.dotSize;
-              circle.setAttribute('r', dotSize.toString());
-              circle.setAttribute('cx', point.x.toString());
-              circle.setAttribute('cy', point.y.toString());
-              circle.setAttribute('fill', color);
-              svg.appendChild(circle);
+            var color = _a.color,
+              point = _a.point;
+            var circle = document.createElement("circle");
+            // var dotSize = typeof _this.dotSize === "function" ? _this.dotSize() : _this.dotSize;
+            var dotSize = typeof _a.dotSize
+              ? _a.dotSize
+              : typeof _this.dotSize === "function"
+              ? _this.dotSize()
+              : _this.dotSize; // Enhance undo
+            circle.setAttribute("r", dotSize.toString());
+            circle.setAttribute("cx", point.x.toString());
+            circle.setAttribute("cy", point.y.toString());
+            circle.setAttribute("fill", color);
+            svg.appendChild(circle);
           });
           var prefix = 'data:image/svg+xml;base64,';
           var header = '<svg' +
@@ -533,5 +571,3 @@ const content = `
 
 })));
 `;
-
-export default content;

--- a/index.d.ts
+++ b/index.d.ts
@@ -9,32 +9,52 @@ declare module "react-native-signature-canvas" {
   type ForwardRef<T, P> = React.ForwardRefExoticComponent<React.PropsWithoutRef<P> & React.RefAttributes<T>>;
 
   type SignatureViewProps = {
-    webStyle?: string;
-    onOK?: (signature: string) => void;
-    onEmpty?: () => void;
-    onClear?: () => void;
-    onBegin?: () => void;
-    onEnd?: () => void;
-    descriptionText?: string;
+    androidHardwareAccelerationDisabled?: boolean;
+    autoClear?: boolean;
+    backgroundColor?: string;
+    bgHeight?: number;
+    bgWidth?: number;
+    bgSrc?: string;
     clearText?: string;
     confirmText?: string;
     customHtml?: string | null | undefined;
-    autoClear?: boolean;
-    trimWhitespace?: boolean;
-    rotated?: boolean;
-    imageType?: ImageType;
     dataURL?: DataURL;
+    descriptionText?: string;
+    dotSize?: number;
+    imageType?: ImageType;
+    minWidth?: number;
+    maxWidth?: number;
+    onOK?: (signature: string) => void;
+    onEmpty?: () => void;
+    onClear?: () => void;
+    onUndo?: () => void;
+    onDraw?: () => void;
+    onErase?: () => void;
+    onGetData?: () => void;
+    onChangePenColo?: () => void;
+    onBegin?: () => void;
+    onEnd?: () => void;
+    overlayHeight?: number;
+    overlayWidth?: number;
+    overlaySrc?: string;
     penColor?: string;
-    backgroundColor?: string;
-    dotSize?: number,
-    minWidth?: number,
-    androidHardwareAccelerationDisabled?: boolean;
-    style?: StyleProp<ViewStyle>
+    rotated?: boolean;
+    style?: StyleProp<ViewStyle>;
+    scrollable?: boolean;
+    trimWhitespace?: boolean;
+    webStyle?: string;
+    webviewContainerStyle?: StyleProp<ViewStyle>;
   }
 
   export type SignatureViewRef = {
-    readSignature: () => void;
+    changePenColor: (color: string) => void;
     clearSignature: () => void;
+    cropWhitespace: (url: string) => void;
+    draw: () => void;
+    erase: () => void;
+    getData: () => void;
+    readSignature: () => void;
+    undo: () => void;
   }
 
   const SignatureView: ForwardRef<SignatureViewRef, SignatureViewProps>

--- a/index.d.ts
+++ b/index.d.ts
@@ -28,6 +28,7 @@ declare module "react-native-signature-canvas" {
     onEmpty?: () => void;
     onClear?: () => void;
     onUndo?: () => void;
+    onRedo?: () => void;
     onDraw?: () => void;
     onErase?: () => void;
     onGetData?: () => void;
@@ -55,6 +56,7 @@ declare module "react-native-signature-canvas" {
     getData: () => void;
     readSignature: () => void;
     undo: () => void;
+    redo: () => void;
   }
 
   const SignatureView: ForwardRef<SignatureViewRef, SignatureViewProps>

--- a/index.js
+++ b/index.js
@@ -17,34 +17,41 @@ const styles = StyleSheet.create({
 });
 
 const SignatureView = forwardRef(({
-  webStyle = "",
-  onOK = () => { },
-  onEmpty = () => { },
-  onClear = () => { },
+  androidHardwareAccelerationDisabled = false,
+  autoClear = false,
+  backgroundColor = "",
+  bgHeight = 0,
+  bgWidth = 0,
+  bgSrc = null,
+  clearText = "Clear",
+  confirmText = "Confirm",
+  customHtml = null,
+  dataURL = "",
+  descriptionText = "Sign above",
+  dotSize = 0,
+  imageType = "",
+  minWidth = 0.5,
+  maxWidth = 2.5,
+  onOK = () => {},
+  onEmpty = () => {},
+  onClear = () => {},
   onUndo=()=>{},
   onDraw=()=>{},
   onErase=()=>{},
   onGetData=()=>{},
   onChangePenColor=()=>{},
-  onBegin = () => { },
-  onEnd = () => { },
-  descriptionText = "Sign above",
-  clearText = "Clear",
-  confirmText = "Confirm",
-  customHtml = null,
-  autoClear = false,
-  trimWhitespace = false,
-  rotated = false,
-  imageType = "",
-  dataURL = "",
+  onBegin = () => {},
+  onEnd = () => {},
+  overlayHeight = 0,
+  overlayWidth = 0,
+  overlaySrc = null,
   penColor = "",
-  backgroundColor = "",
-  dotSize = 0,
-  minWidth = 0.5,
-  androidHardwareAccelerationDisabled = false,
+  rotated = false,
   style = null,
-  webviewContainerStyle = null,
   scrollable = false,
+  trimWhitespace = false,
+  webStyle = "",
+  webviewContainerStyle = null,
 }, ref) => {
   const [loading, setLoading] = useState(true);
   const webViewRef = useRef();
@@ -59,8 +66,15 @@ const SignatureView = forwardRef(({
     injectedJavaScript = injectedJavaScript.replace(/<%backgroundColor%>/g, backgroundColor);
     injectedJavaScript = injectedJavaScript.replace(/<%dotSize%>/g, dotSize);
     injectedJavaScript = injectedJavaScript.replace(/<%minWidth%>/g, minWidth);
+    injectedJavaScript = injectedJavaScript.replace(/<%maxWidth%>/g, maxWidth);
     
     let html = htmlContentValue(injectedJavaScript);
+    html = html.replace(/<%bgWidth%>/g, bgWidth);
+    html = html.replace(/<%bgHeight%>/g, bgHeight);
+    html = html.replace(/<%bgSrc%>/g, bgSrc);
+    html = html.replace(/<%overlayWidth%>/g, overlayWidth);
+    html = html.replace(/<%overlayHeight%>/g, overlayHeight);
+    html = html.replace(/<%overlaySrc%>/g, overlaySrc);
     html = html.replace(/<%style%>/g, webStyle);
     html = html.replace(/<%description%>/g, descriptionText);
     html = html.replace(/<%confirm%>/g, confirmText);
@@ -148,10 +162,7 @@ const SignatureView = forwardRef(({
     }
   }), [webViewRef]);
 
-  const renderError = e => {
-    const { nativeEvent } = e;
-    console.warn("WebView error: ", nativeEvent);
-  };
+  const renderError = ({nativeEvent}) => console.warn("WebView error: ", nativeEvent);
 
   return (
     <View style={[styles.webBg, style]}>

--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ const SignatureView = forwardRef(({
   onEmpty = () => {},
   onClear = () => {},
   onUndo=()=>{},
+  onRedo=()=>{},
   onDraw=()=>{},
   onErase=()=>{},
   onGetData=()=>{},
@@ -110,6 +111,9 @@ const SignatureView = forwardRef(({
       case "UNDO":
         onUndo();
         break;
+      case "REDO":
+        onRedo();
+        break;
       case "DRAW":
         onDraw();
         break;
@@ -138,6 +142,11 @@ const SignatureView = forwardRef(({
     undo: () => {
       if (webViewRef.current) {
         webViewRef.current.injectJavaScript("undo();true;");
+      }
+    },
+    redo: () => {
+      if (webViewRef.current) {
+        webViewRef.current.injectJavaScript("redo();true;");
       }
     },
     draw: () => {


### PR DESCRIPTION
Fixed the issues of `undo()` and erasing, where `undo()` would cause the erased lines to appear as drawn ones. Added a `redo()` function, which lets users redo the last undid strokes (resets after each new stroke as common in other drawing apps). Added a background image prop that cannot be erased and can be drawn on. Added an overlay image prop, that lets users put an image on top of the canvas (useful with .png images to have drawing guidelines). Edited the `readme.md` file to accommodate the new changes. Edited the `index.d.ts` file to reference all the new props and methods.