### PR TITLE
Fix type of customHtml prop in type definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import SignatureScreen from 'react-native-signature-canvas';
 | bgSrc                               |  `string`  | background image source uri (_url_)                                                                                                                  |
 | clearText                           |  `string`  | clear button text                                                                                                                                     |
 | confirmText                         |  `string`  | save button text                                                                                                                                      |
-| customHtml                          | `function` | html string that lets you modify things like the layout or elements                                                                                   |
+| customHtml                          | `(injectedJavaScript: string) => string` | html string that lets you modify things like the layout or elements                                                                                   |
 | dataURL                             |  `string`  | default is "", Base64 string, draws saved signature from dataURL.                                                                                     |
 | descriptionText                     |  `string`  | description text for signature                                                                                                                        |
 | dotSize                             |  `number`  | radius of a single dot _(not stroke width)_                                                                                                           |

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ declare module "react-native-signature-canvas" {
     bgSrc?: string;
     clearText?: string;
     confirmText?: string;
-    customHtml?: string | null | undefined;
+    customHtml?: (injectedJavaScript: string) => string;
     dataURL?: DataURL;
     descriptionText?: string;
     dotSize?: number;


### PR DESCRIPTION
`index.js` has

```js
const htmlContentValue = customHtml ? customHtml : htmlContent;
// ...
let html = htmlContentValue(injectedJavaScript);
```

So the type of the `customHtml` prop should really be `(injectedJavaScript: string) => string`.