### PR TITLE
Added missing type for onGetData

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -31,7 +31,7 @@ declare module "react-native-signature-canvas" {
     onRedo?: () => void;
     onDraw?: () => void;
     onErase?: () => void;
-    onGetData?: () => void;
+    onGetData?: (data: any) => void;
     onChangePenColor?: () => void;
     onChangePenSize?: () => void;
     onBegin?: () => void;


### PR DESCRIPTION
A data parameter is required to be passed to `onGetData` method and this PR adds type support for that to avoid lint errors.