### PR TITLE
fix(android): sigsegv crash on android

### DIFF
--- a/index.js
+++ b/index.js
@@ -193,6 +193,7 @@ const SignatureView = forwardRef(({
         bounces={false}
         style={[webviewContainerStyle]}
         scrollEnabled={scrollable}
+        androidLayerType="hardware"
         androidHardwareAccelerationDisabled={androidHardwareAccelerationDisabled}
         ref={webViewRef}
         useWebKit={true}


### PR DESCRIPTION
This issue is being mentioned and referenced here.
https://github.com/facebook/react-native/issues/32547

It's causing a reproducible crash in the app I'm developing, I'm hoping to solve this for future developers.
This pull request will solve this issue.
https://github.com/YanYuanFE/react-native-signature-canvas/issues/296