### PR TITLE
feat: export SignatureViewProps

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,7 +10,7 @@ declare module "react-native-signature-canvas" {
     React.PropsWithoutRef<P> & React.RefAttributes<T>
   >;
 
-  type SignatureViewProps = {
+  export type SignatureViewProps = {
     androidHardwareAccelerationDisabled?: boolean;
     autoClear?: boolean;
     backgroundColor?: string;


### PR DESCRIPTION
Hi there.

I have a core packages where I centralize all libraries. To be possible re export the react-native-signature-canvas, exposing the props I wanted to export the SignatureViewProps, It is that possible? 
@YanYuanFE 
