### PR TITLE
fix: add originWhitelist prop

### DIFF
--- a/index.js
+++ b/index.js
@@ -280,6 +280,7 @@ const SignatureView = forwardRef(
           ref={webViewRef}
           useWebKit={true}
           source={source}
+          originWhitelist={['*']}
           onMessage={getSignature}
           javaScriptEnabled={true}
           onError={renderError}


### PR DESCRIPTION

React Native WebView API Reference:
> Note that using static HTML requires the WebView property [originWhitelist](https://github.com/react-native-webview/react-native-webview/blob/master/docs/Reference.md#originwhitelist) to ['*']

