### PR TITLE
feat: enhance type definitions and add loading overlay props for signature canvas

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,103 +1,103 @@
 declare module "react-native-signature-canvas" {
   import React from "react";
-  import {StyleProp, ViewStyle, ActivityIndicator} from "react-native";
-  import {WebViewProps} from "react-native-webview";
+  import { StyleProp, ViewStyle, ActivityIndicator } from "react-native";
+  import { WebViewProps } from "react-native-webview";
 
   // Enhanced type definitions with better error handling
 
-    type ImageType = "image/png" | "image/jpeg" | "image/svg+xml";
+  type ImageType = "image/png" | "image/jpeg" | "image/svg+xml";
 
-    type DataURL = string; // Simplified - should be base64 data URL
+  type DataURL = string; // Simplified - should be base64 data URL
 
-    type ForwardRef<T, P> = React.ForwardRefExoticComponent<
-        React.PropsWithoutRef<P> & React.RefAttributes<T>
-    >;
+  type ForwardRef<T, P> = React.ForwardRefExoticComponent<
+    React.PropsWithoutRef<P> & React.RefAttributes<T>
+  >;
 
-    // Enhanced callback types
-    type SignatureCallback = (signature: string) => void;
-    type EmptyCallback = () => void;
-    type ErrorCallback = (error: Error) => void;
+  // Enhanced callback types
+  type SignatureCallback = (signature: string) => void;
+  type EmptyCallback = () => void;
+  type ErrorCallback = (error: Error) => void;
 
-    type LoadingOverlayProps = {
-        loadingOverlayStyle?: StyleProp<ViewStyle>;
-        activityIndicatorProps?: React.ComponentProps<typeof ActivityIndicator>;
-    }
+  type LoadingOverlayProps = {
+    loadingOverlayStyle?: StyleProp<ViewStyle>;
+    activityIndicatorProps?: React.ComponentProps<typeof ActivityIndicator>;
+  }
 
-    export type SignatureViewProps = {
-        androidHardwareAccelerationDisabled?: boolean;
-        autoClear?: boolean;
-        backgroundColor?: string;
-        bgHeight?: number;
-        bgWidth?: number;
-        bgSrc?: string;
-        clearText?: string;
-        confirmText?: string;
-        customHtml?: (injectedJavaScript: string) => string;
-        dataURL?: DataURL;
-        descriptionText?: string;
-        dotSize?: number;
-        imageType?: ImageType;
-        minWidth?: number;
-        maxWidth?: number;
-        minDistance?: number;
-        onError?: ErrorCallback; // Added missing prop
-        nestedScrollEnabled?: boolean;
-        showsVerticalScrollIndicator?: boolean;
-        onOK?: SignatureCallback;
-        onEmpty?: EmptyCallback;
-        onClear?: EmptyCallback;
-        onUndo?: EmptyCallback;
-        onRedo?: EmptyCallback;
-        onDraw?: EmptyCallback;
-        onErase?: EmptyCallback;
-        onGetData?: (data: string) => void; // Should be JSON string
-        onChangePenColor?: EmptyCallback;
-        onChangePenSize?: EmptyCallback;
-        onBegin?: EmptyCallback;
-        onEnd?: EmptyCallback;
-        onLoadEnd?: EmptyCallback;
-        onError?: ErrorCallback; // Added missing error callback
-        overlayHeight?: number;
-        overlayWidth?: number;
-        overlaySrc?: string;
-        penColor?: string;
-        rotated?: boolean;
-        style?: StyleProp<ViewStyle>;
-        scrollable?: boolean;
-        trimWhitespace?: boolean;
-        webStyle?: string;
-        webviewContainerStyle?: StyleProp<ViewStyle>;
-        androidLayerType?: "none" | "software" | "hardware";
-        webviewProps?: Partial<WebViewProps>;
-        loadingOverlayProps?: LoadingOverlayProps
-    };
+  export type SignatureViewProps = {
+    androidHardwareAccelerationDisabled?: boolean;
+    autoClear?: boolean;
+    backgroundColor?: string;
+    bgHeight?: number;
+    bgWidth?: number;
+    bgSrc?: string;
+    clearText?: string;
+    confirmText?: string;
+    customHtml?: (injectedJavaScript: string) => string;
+    dataURL?: DataURL;
+    descriptionText?: string;
+    dotSize?: number;
+    imageType?: ImageType;
+    minWidth?: number;
+    maxWidth?: number;
+    minDistance?: number;
+    onError?: ErrorCallback; // Added missing prop
+    nestedScrollEnabled?: boolean;
+    showsVerticalScrollIndicator?: boolean;
+    onOK?: SignatureCallback;
+    onEmpty?: EmptyCallback;
+    onClear?: EmptyCallback;
+    onUndo?: EmptyCallback;
+    onRedo?: EmptyCallback;
+    onDraw?: EmptyCallback;
+    onErase?: EmptyCallback;
+    onGetData?: (data: string) => void; // Should be JSON string
+    onChangePenColor?: EmptyCallback;
+    onChangePenSize?: EmptyCallback;
+    onBegin?: EmptyCallback;
+    onEnd?: EmptyCallback;
+    onLoadEnd?: EmptyCallback;
+    onError?: ErrorCallback; // Added missing error callback
+    overlayHeight?: number;
+    overlayWidth?: number;
+    overlaySrc?: string;
+    penColor?: string;
+    rotated?: boolean;
+    style?: StyleProp<ViewStyle>;
+    scrollable?: boolean;
+    trimWhitespace?: boolean;
+    webStyle?: string;
+    webviewContainerStyle?: StyleProp<ViewStyle>;
+    androidLayerType?: "none" | "software" | "hardware";
+    webviewProps?: Partial<WebViewProps>;
+    loadingOverlayProps?: LoadingOverlayProps; // Added missing prop for loading overlay
+  };
 
-    export type SignatureViewRef = {
-        changePenColor: (color: string) => void;
-        changePenSize: (minW: number, maxW: number) => void;
-        clearSignature: () => void;
-        draw: () => void;
-        erase: () => void;
-        getData: () => void;
-        readSignature: () => void;
-        undo: () => void;
-        redo: () => void;
-        fromData: (pointGroups: any[], suppressClear?: boolean) => void;
-        /** Set dataURL without causing WebView reload - useful for restoring signatures */
-        setDataURL: (url: string) => void;
-        /** Force reinitialize WebView - useful for bottom sheets/modals where WebView state is lost */
-        reinitialize: () => void;
-    };
+  export type SignatureViewRef = {
+    changePenColor: (color: string) => void;
+    changePenSize: (minW: number, maxW: number) => void;
+    clearSignature: () => void;
+    draw: () => void;
+    erase: () => void;
+    getData: () => void;
+    readSignature: () => void;
+    undo: () => void;
+    redo: () => void;
+    fromData: (pointGroups: any[], suppressClear?: boolean) => void;
+    /** Set dataURL without causing WebView reload - useful for restoring signatures */
+    setDataURL: (url: string) => void;
+    /** Force reinitialize WebView - useful for bottom sheets/modals where WebView state is lost */
+    reinitialize: () => void;
+  };
 
-    // Enhanced component interface with better type safety
-    interface SignatureCanvasComponent
-        extends ForwardRef<SignatureViewRef, SignatureViewProps> {
-        displayName?: string;
-    }
+  // Enhanced component interface with better type safety
+  interface SignatureCanvasComponent
+    extends ForwardRef<SignatureViewRef, SignatureViewProps> {
+    displayName?: string;
+  }
 
-    const SignatureView: SignatureCanvasComponent;
-    export default SignatureView;
+  const SignatureView: SignatureCanvasComponent;
+  export default SignatureView;
 
-    // Export additional types for external use
-    export {SignatureViewProps, SignatureViewRef, ImageType, DataURL};
+  // Export additional types for external use
+  export { SignatureViewProps, SignatureViewRef, ImageType, DataURL };
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,97 +1,103 @@
 declare module "react-native-signature-canvas" {
   import React from "react";
-  import { StyleProp, ViewStyle } from "react-native";
-  import { WebViewProps } from "react-native-webview";
+  import {StyleProp, ViewStyle, ActivityIndicator} from "react-native";
+  import {WebViewProps} from "react-native-webview";
 
   // Enhanced type definitions with better error handling
 
-  type ImageType = "image/png" | "image/jpeg" | "image/svg+xml";
+    type ImageType = "image/png" | "image/jpeg" | "image/svg+xml";
 
-  type DataURL = string; // Simplified - should be base64 data URL
+    type DataURL = string; // Simplified - should be base64 data URL
 
-  type ForwardRef<T, P> = React.ForwardRefExoticComponent<
-    React.PropsWithoutRef<P> & React.RefAttributes<T>
-  >;
+    type ForwardRef<T, P> = React.ForwardRefExoticComponent<
+        React.PropsWithoutRef<P> & React.RefAttributes<T>
+    >;
 
-  // Enhanced callback types
-  type SignatureCallback = (signature: string) => void;
-  type EmptyCallback = () => void;
-  type ErrorCallback = (error: Error) => void;
+    // Enhanced callback types
+    type SignatureCallback = (signature: string) => void;
+    type EmptyCallback = () => void;
+    type ErrorCallback = (error: Error) => void;
 
-  export type SignatureViewProps = {
-    androidHardwareAccelerationDisabled?: boolean;
-    autoClear?: boolean;
-    backgroundColor?: string;
-    bgHeight?: number;
-    bgWidth?: number;
-    bgSrc?: string;
-    clearText?: string;
-    confirmText?: string;
-    customHtml?: (injectedJavaScript: string) => string;
-    dataURL?: DataURL;
-    descriptionText?: string;
-    dotSize?: number;
-    imageType?: ImageType;
-    minWidth?: number;
-    maxWidth?: number;
-    minDistance?: number;
-    onError?: ErrorCallback; // Added missing prop
-    nestedScrollEnabled?: boolean;
-    showsVerticalScrollIndicator?: boolean;
-    onOK?: SignatureCallback;
-    onEmpty?: EmptyCallback;
-    onClear?: EmptyCallback;
-    onUndo?: EmptyCallback;
-    onRedo?: EmptyCallback;
-    onDraw?: EmptyCallback;
-    onErase?: EmptyCallback;
-    onGetData?: (data: string) => void; // Should be JSON string
-    onChangePenColor?: EmptyCallback;
-    onChangePenSize?: EmptyCallback;
-    onBegin?: EmptyCallback;
-    onEnd?: EmptyCallback;
-    onLoadEnd?: EmptyCallback;
-    onError?: ErrorCallback; // Added missing error callback
-    overlayHeight?: number;
-    overlayWidth?: number;
-    overlaySrc?: string;
-    penColor?: string;
-    rotated?: boolean;
-    style?: StyleProp<ViewStyle>;
-    scrollable?: boolean;
-    trimWhitespace?: boolean;
-    webStyle?: string;
-    webviewContainerStyle?: StyleProp<ViewStyle>;
-    androidLayerType?: "none" | "software" | "hardware";
-    webviewProps?: Partial<WebViewProps>;
-  };
+    type LoadingOverlayProps = {
+        loadingOverlayStyle?: StyleProp<ViewStyle>;
+        activityIndicatorProps?: React.ComponentProps<typeof ActivityIndicator>;
+    }
 
-  export type SignatureViewRef = {
-    changePenColor: (color: string) => void;
-    changePenSize: (minW: number, maxW: number) => void;
-    clearSignature: () => void;
-    draw: () => void;
-    erase: () => void;
-    getData: () => void;
-    readSignature: () => void;
-    undo: () => void;
-    redo: () => void;
-    fromData: (pointGroups: any[], suppressClear?: boolean) => void;
-    /** Set dataURL without causing WebView reload - useful for restoring signatures */
-    setDataURL: (url: string) => void;
-    /** Force reinitialize WebView - useful for bottom sheets/modals where WebView state is lost */
-    reinitialize: () => void;
-  };
+    export type SignatureViewProps = {
+        androidHardwareAccelerationDisabled?: boolean;
+        autoClear?: boolean;
+        backgroundColor?: string;
+        bgHeight?: number;
+        bgWidth?: number;
+        bgSrc?: string;
+        clearText?: string;
+        confirmText?: string;
+        customHtml?: (injectedJavaScript: string) => string;
+        dataURL?: DataURL;
+        descriptionText?: string;
+        dotSize?: number;
+        imageType?: ImageType;
+        minWidth?: number;
+        maxWidth?: number;
+        minDistance?: number;
+        onError?: ErrorCallback; // Added missing prop
+        nestedScrollEnabled?: boolean;
+        showsVerticalScrollIndicator?: boolean;
+        onOK?: SignatureCallback;
+        onEmpty?: EmptyCallback;
+        onClear?: EmptyCallback;
+        onUndo?: EmptyCallback;
+        onRedo?: EmptyCallback;
+        onDraw?: EmptyCallback;
+        onErase?: EmptyCallback;
+        onGetData?: (data: string) => void; // Should be JSON string
+        onChangePenColor?: EmptyCallback;
+        onChangePenSize?: EmptyCallback;
+        onBegin?: EmptyCallback;
+        onEnd?: EmptyCallback;
+        onLoadEnd?: EmptyCallback;
+        onError?: ErrorCallback; // Added missing error callback
+        overlayHeight?: number;
+        overlayWidth?: number;
+        overlaySrc?: string;
+        penColor?: string;
+        rotated?: boolean;
+        style?: StyleProp<ViewStyle>;
+        scrollable?: boolean;
+        trimWhitespace?: boolean;
+        webStyle?: string;
+        webviewContainerStyle?: StyleProp<ViewStyle>;
+        androidLayerType?: "none" | "software" | "hardware";
+        webviewProps?: Partial<WebViewProps>;
+        loadingOverlayProps?: LoadingOverlayProps
+    };
 
-  // Enhanced component interface with better type safety
-  interface SignatureCanvasComponent
-    extends ForwardRef<SignatureViewRef, SignatureViewProps> {
-    displayName?: string;
-  }
+    export type SignatureViewRef = {
+        changePenColor: (color: string) => void;
+        changePenSize: (minW: number, maxW: number) => void;
+        clearSignature: () => void;
+        draw: () => void;
+        erase: () => void;
+        getData: () => void;
+        readSignature: () => void;
+        undo: () => void;
+        redo: () => void;
+        fromData: (pointGroups: any[], suppressClear?: boolean) => void;
+        /** Set dataURL without causing WebView reload - useful for restoring signatures */
+        setDataURL: (url: string) => void;
+        /** Force reinitialize WebView - useful for bottom sheets/modals where WebView state is lost */
+        reinitialize: () => void;
+    };
 
-  const SignatureView: SignatureCanvasComponent;
-  export default SignatureView;
+    // Enhanced component interface with better type safety
+    interface SignatureCanvasComponent
+        extends ForwardRef<SignatureViewRef, SignatureViewProps> {
+        displayName?: string;
+    }
 
-  // Export additional types for external use
-  export { SignatureViewProps, SignatureViewRef, ImageType, DataURL };
+    const SignatureView: SignatureCanvasComponent;
+    export default SignatureView;
+
+    // Export additional types for external use
+    export {SignatureViewProps, SignatureViewRef, ImageType, DataURL};
 }

--- a/index.js
+++ b/index.js
@@ -60,6 +60,7 @@ const getParamForInjection = (param) => {
 const SignatureView = forwardRef(
   (
     {
+      loadingOverlayProps = {},
       androidHardwareAccelerationDisabled = false,
       autoClear = false,
       backgroundColor = "",
@@ -439,13 +440,13 @@ const SignatureView = forwardRef(
           {...webviewProps}
         />
         {(loading || hasError) && (
-          <View style={styles.loadingOverlayContainer}>
+          <View style={[styles.loadingOverlayContainer, loadingOverlayProps.loadingOverlayStyle]}>
             {hasError ? (
               <Text style={{ color: '#ff0000', textAlign: 'center', padding: 10 }}>
                 Error loading signature pad{retryCount > 0 ? ` (Retry ${retryCount}/${maxRetries})` : ''}
               </Text>
             ) : (
-              <ActivityIndicator color={"#007AFF"} size="small" />
+              <ActivityIndicator color={"#007AFF"} size="small" {...loadingOverlayProps.activityIndicatorProps} />
             )}
           </View>
         )}


### PR DESCRIPTION
### Feature: Customizable loading overlay for `SignatureView`

#### Problem

Currently the `SignatureView` component renders a fixed loading overlay while the WebView initializes.
The overlay cannot be styled or configured, which creates several UX issues:

* White flash on Android before the signature pad appears
* Incorrect appearance in dark mode
* No control over `ActivityIndicator` color or size
* Inconsistent UI with application theme

Developers cannot adapt the loading state to match their app styling.

#### Solution

This PR introduces a new `loadingOverlayProps` prop that allows customization of the loading overlay and activity indicator.

The prop supports:

* custom overlay styles
* passing props directly to `ActivityIndicator`

This enables proper dark/light mode support and consistent theming without modifying the library source.

#### Changes

* Added `loadingOverlayProps` to `SignatureView`
* Applied custom overlay styling via `loadingOverlayProps.loadingOverlayStyle`
* Forwarded `ActivityIndicator` props via `loadingOverlayProps.activityIndicatorProps`

#### Backward compatibility

This change is fully backward compatible.
If `loadingOverlayProps` is not provided, the component behaves exactly as before.

#### Example

```jsx
<SignatureView
  loadingOverlayProps={{
    loadingOverlayStyle: { backgroundColor: '#000' },
    activityIndicatorProps: { color: '#fff', size: 'large' }
  }}
/>
```