### PR TITLE
Fix clientWidth and clientHeight being 0 because of initial call of resizeCanvas()

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # React Native Signature Canvas
 
+This is a fork of [react-native-signature-canvas](https://github.com/YanYuanFE/react-native-signature-canvas/) to fix [this issue](https://github.com/YanYuanFE/react-native-signature-canvas/issues/412).
+
 [![](https://img.shields.io/npm/l/react-native-signature-canvas.svg)](https://www.npmjs.com/package/react-native-signature-canvas)
 [![](https://img.shields.io/npm/v/react-native-signature-canvas)](https://www.npmjs.com/package/react-native-signature-canvas)
 ![npm](https://img.shields.io/npm/dt/react-native-signature-canvas)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # React Native Signature Canvas
 
-This is a fork of [react-native-signature-canvas](https://github.com/YanYuanFE/react-native-signature-canvas/) to fix [this issue](https://github.com/YanYuanFE/react-native-signature-canvas/issues/412).
-Thanks to __abdumo1993__ for the fix.
-
 [![](https://img.shields.io/npm/l/react-native-signature-canvas.svg)](https://www.npmjs.com/package/react-native-signature-canvas)
 [![](https://img.shields.io/npm/v/react-native-signature-canvas)](https://www.npmjs.com/package/react-native-signature-canvas)
 ![npm](https://img.shields.io/npm/dt/react-native-signature-canvas)

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # React Native Signature Canvas
 
 This is a fork of [react-native-signature-canvas](https://github.com/YanYuanFE/react-native-signature-canvas/) to fix [this issue](https://github.com/YanYuanFE/react-native-signature-canvas/issues/412).
+Thanks to __abdumo1993__ for the fix.
 
 [![](https://img.shields.io/npm/l/react-native-signature-canvas.svg)](https://www.npmjs.com/package/react-native-signature-canvas)
 [![](https://img.shields.io/npm/v/react-native-signature-canvas)](https://www.npmjs.com/package/react-native-signature-canvas)

--- a/h5/js/app.js
+++ b/h5/js/app.js
@@ -46,7 +46,11 @@ export default `
     });
 
     // Initial canvas setup
-    resizeCanvas();
+    const observer = new ResizeObserver(() => {
+        resizeCanvas();
+    });
+    
+    observer.observe(canvas);
 
     function clearSignature () {
         signaturePad.clear();


### PR DESCRIPTION
This is a fix for [issue 412](https://github.com/YanYuanFE/react-native-signature-canvas/issues/412).

Thanks to [abdumo1993](https://github.com/abdumo1993) who found the issue and provided the fix.